### PR TITLE
Fixed res.send() bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ app.get('/', function(req, res, next) {
     res.setHeader('Content-Type', 'text/html')
     res.write('<p>views: ' + req.session.views + '</p>')
     res.write('<p>expires in: ' + (req.session.cookie.maxAge / 1000) + 's</p>')
-    res.end()
+    res.send()
   } else {
     req.session.views = 1
-    res.end('welcome to the session demo. refresh!')
+    res.send('welcome to the session demo. refresh!')
   }
 })
 ```


### PR DESCRIPTION
res.send() was mistakenly written as res.end() in two places in an example code.